### PR TITLE
added more tests for multiple minuses

### DIFF
--- a/src/test/kotlin/de/lostmekka/kotlinplayground/calculator/CalculatorTest.kt
+++ b/src/test/kotlin/de/lostmekka/kotlinplayground/calculator/CalculatorTest.kt
@@ -55,6 +55,7 @@ object CalculatorTest : Spek({
                 val totalSign = Math.pow(-1.0, n.toDouble())
                 "${minusSigns}1" shouldBe totalSign
                 "0${minusSigns}1" shouldBe totalSign
+                "5${minusSigns}2" shouldBe 5 + totalSign * 2
             }
         }
 


### PR DESCRIPTION
I added another test for formulas with multiple minuses.
I came across this, when implementing a solution.
Part of it was removing occurences of `--`, which is obviously wrong on second thought, but worked here, because I ended up either with `0-1` or `01` which my code could handle.
Of course `01` is not what we want here, but it evaluates to `1.0` when parsed as Double just as expected for `0--1`.
For this reason I added another test, that does not pass, if the minuses are just removed.